### PR TITLE
More DelegatingDeedHolder tests

### DIFF
--- a/test/DelegatingDeedHolder.js
+++ b/test/DelegatingDeedHolder.js
@@ -17,11 +17,14 @@ contract("DelegatingDeedHolder", (accounts) => {
     // ENS related constants
     const TLD = "eth"
     const DOMAIN = "name"
+    const SUBDOMAIN = "sub"
     const ROOT_NAMEHASH = namehash("")
     const TLD_NAMEHASH = namehash(TLD)
     const DOMAIN_NAMEHASH = namehash(`${DOMAIN}.${TLD}`)
+    const SUBDOMAIN_NAMEHASH = namehash(`${SUBDOMAIN}.${DOMAIN}.${TLD}`)
     const TLD_REGISTRAR_LABEL = web3.sha3(TLD)
     const DOMAIN_REGISTRAR_LABEL = web3.sha3(DOMAIN)
+    const SUBDOMAIN_REGISTRAR_LABEL = web3.sha3(SUBDOMAIN)
 
     let ens
     let registrar
@@ -71,5 +74,12 @@ contract("DelegatingDeedHolder", (accounts) => {
         await assertRevert(async () => {
             await delegatingDeedHolder.setManager(DOMAIN_REGISTRAR_LABEL, newDomainRegistrar.address)
         })
+    })
+
+    it("allows the manager to manage subnodes", async () => {
+        await delegatingDeedHolder.setManager(DOMAIN_REGISTRAR_LABEL, domainRegistrar.address)
+
+        await domainRegistrar.register(SUBDOMAIN_REGISTRAR_LABEL, NEW_HOLDER)
+        assert(NEW_HOLDER, await ens.owner(SUBDOMAIN_NAMEHASH))
     })
 })

--- a/test/ens/FIFSRegistrar.sol
+++ b/test/ens/FIFSRegistrar.sol
@@ -1,0 +1,39 @@
+pragma solidity ^0.4.0;
+
+import '../../contracts/ens/AbstractENS.sol';
+
+/**
+ * A registrar that allocates subdomains to the first person to claim them.
+ */
+contract FIFSRegistrar {
+    AbstractENS ens;
+    bytes32 rootNode;
+
+    modifier only_owner(bytes32 subnode) {
+        var node = sha3(rootNode, subnode);
+        var currentOwner = ens.owner(node);
+
+        if (currentOwner != 0 && currentOwner != msg.sender) throw;
+
+        _;
+    }
+
+    /**
+     * Constructor.
+     * @param ensAddr The address of the ENS registry.
+     * @param node The node that this registrar administers.
+     */
+    function FIFSRegistrar(AbstractENS ensAddr, bytes32 node) {
+        ens = ensAddr;
+        rootNode = node;
+    }
+
+    /**
+     * Register a name, or change the owner of an existing registration.
+     * @param subnode The hash of the label to register.
+     * @param owner The address of the new owner.
+     */
+    function register(bytes32 subnode, address owner) only_owner(subnode) {
+        ens.setSubnodeOwner(rootNode, subnode, owner);
+    }
+}


### PR DESCRIPTION
* Actually use registrars as the managers, rather than resolver (oops)
* Test that the manager can actually control the ENS node (e.g. creating a subdomain)