### PR TITLE
Fix tests from missing imports and babel-register

### DIFF
--- a/test/ens/ENS.sol
+++ b/test/ens/ENS.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.4.0;
 
-import "../../contracts/ens/AbstractENS.sol";
+import "@aragon/os/contracts/lib/ens/AbstractENS.sol";
 
 
 /**

--- a/test/ens/FIFSRegistrar.sol
+++ b/test/ens/FIFSRegistrar.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.4.0;
 
-import '../../contracts/ens/AbstractENS.sol';
+import "@aragon/os/contracts/lib/ens/AbstractENS.sol";
 
 /**
  * A registrar that allocates subdomains to the first person to claim them.

--- a/test/ens/PublicResolver.sol
+++ b/test/ens/PublicResolver.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.4.0;
 
-import "../../contracts/ens/AbstractENS.sol";
+import "@aragon/os/contracts/lib/ens/AbstractENS.sol";
 
 /**
  * A simple resolver anyone can use; only allows the owner of a node to set its

--- a/test/ens/Registrar.sol
+++ b/test/ens/Registrar.sol
@@ -14,7 +14,7 @@ The plan is to test the basic features and then move to a new contract in at mos
 */
 
 
-import '../../contracts/ens/AbstractENS.sol';
+import "@aragon/os/contracts/lib/ens/AbstractENS.sol";
 
 
 /**

--- a/test/mocks/MockResolver.sol
+++ b/test/mocks/MockResolver.sol
@@ -1,6 +1,6 @@
 pragma solidity 0.4.18;
 
-import "../../contracts/ens/AbstractENS.sol";
+import "@aragon/os/contracts/lib/ens/AbstractENS.sol";
 
 
 contract MockResolver {

--- a/truffle.js
+++ b/truffle.js
@@ -1,3 +1,6 @@
+require('babel-core/register')
+require('babel-polyfill')
+
 const HDWalletProvider = require('truffle-hdwallet-provider')
 
 let rinkebyProvider = {}


### PR DESCRIPTION
@izqui would be great if you could enable aragon-id in travis so we catch this in CI next time :).